### PR TITLE
don't send empty buffers as bad checksums

### DIFF
--- a/src/MicroNMEA.cpp
+++ b/src/MicroNMEA.cpp
@@ -248,7 +248,7 @@ bool MicroNMEA::process(char c)
       return true; // New valid MicroNMEA sentence
     }
     else {
-      if (_badChecksumHandler) 
+      if (_badChecksumHandler && *_buffer != '\0') // don't send empty buffers as bad checksums!
 	(*_badChecksumHandler)(*this);
     }
   }


### PR DESCRIPTION
There is no need to call _badChecksumHandler if the start of _buffer is '\0'.