### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,43 +5,43 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-MicroNMEA		KEYWORD1
+MicroNMEA	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-skipField			KEYWORD2
-parseUnsignedInt		KEYWORD2
-parseFloat			KEYWORD2
-parseDegreeMinute		KEYWORD2
-parseToComma			KEYWORD2
-parseField			KEYWORD2
-generateChecksum		KEYWORD2
-testChecksum			KEYWORD2
-sendSentence			KEYWORD2
-clear				KEYWORD2
-getNavSystem			KEYWORD2
-getNumSatellites		KEYWORD2
-getHDOP				KEYWORD2
-isValid				KEYWORD2
-getLatitude			KEYWORD2
-getLongitude			KEYWORD2
-getAltitude			KEYWORD2
-getYear				KEYWORD2
-getMonth			KEYWORD2
-getDay				KEYWORD2
-getHour				KEYWORD2
-getMinute			KEYWORD2
-getSecond			KEYWORD2
-getHundredths			KEYWORD2
-getSpeed			KEYWORD2
-getCourse			KEYWORD2
-process				KEYWORD2
-setBadChecksumHandler		KEYWORD2
+skipField	KEYWORD2
+parseUnsignedInt	KEYWORD2
+parseFloat	KEYWORD2
+parseDegreeMinute	KEYWORD2
+parseToComma	KEYWORD2
+parseField	KEYWORD2
+generateChecksum	KEYWORD2
+testChecksum	KEYWORD2
+sendSentence	KEYWORD2
+clear	KEYWORD2
+getNavSystem	KEYWORD2
+getNumSatellites	KEYWORD2
+getHDOP	KEYWORD2
+isValid	KEYWORD2
+getLatitude	KEYWORD2
+getLongitude	KEYWORD2
+getAltitude	KEYWORD2
+getYear	KEYWORD2
+getMonth	KEYWORD2
+getDay	KEYWORD2
+getHour	KEYWORD2
+getMinute	KEYWORD2
+getSecond	KEYWORD2
+getHundredths	KEYWORD2
+getSpeed	KEYWORD2
+getCourse	KEYWORD2
+process	KEYWORD2
+setBadChecksumHandler	KEYWORD2
 setUnknownSentenceHandler	KEYWORD2
-getSentence			KEYWORD2
-getTalkerID			KEYWORD2
-getMessageID			KEYWORD2
+getSentence	KEYWORD2
+getTalkerID	KEYWORD2
+getMessageID	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords